### PR TITLE
fix: managing states by each components name

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,31 +1,40 @@
-import createElement from "./createElement.js";
 import Main from "./Main.js";
-import router from "./router.js";
+import BrowserRouter from "./router.js";
 import { MyReact } from "./MyReact.js";
 import FetchPage from "./FetchPage.js";
-import useNavigate from "./useNavigate.js";
-import { parseHTMLToRenderTree } from "./utils.js";
+import { parseHTMLToVDOMTree } from "./utils.js";
+import NavBar from "./NavBar.js";
+import { PathStateContext } from "./PathStateContext.js";
 
 export default function App() {
-  const { currentPath, navigateTo } = useNavigate();
-
+  const [currentPath, setCurrentPath] = MyReact.useState(window.location.pathname);
   const routes = [
     {
       pathname: "/",
-      render() {
-        return MyReact.render(Main, { navigateTo: navigateTo });
-      },
+      component: Main,
     },
+
     {
       pathname: "/fetch",
-      render() {
-        return MyReact.render(FetchPage, { navigateTo: navigateTo });
-      },
+      component: FetchPage,
     },
   ];
-  return parseHTMLToRenderTree`
+
+  return parseHTMLToVDOMTree`
     <div class="App">
-      ${router(currentPath, routes).render()}
+    ${MyReact.render(PathStateContext.Provider, {
+      value: { currentPath: currentPath, setCurrentPath: setCurrentPath },
+      children: [
+        [NavBar, null],
+        [
+          BrowserRouter,
+          {
+            currentPath: currentPath,
+            routes: routes,
+          },
+        ],
+      ],
+    })}
     </div>
   `;
 }

--- a/App.js
+++ b/App.js
@@ -1,20 +1,13 @@
 import Main from "./Main.js";
 import BrowserRouter from "./router.js";
-// import { render } from "./MyReact.js";
-import MyReact from "./MyReact.js";
+import { render } from "./MyReact.js";
 import FetchPage from "./FetchPage.js";
 import { parseHTMLToVDOMTree } from "./utils.js";
 import NavBar from "./NavBar.js";
 import useNavigate from "./useNavigate.js";
 
 export default function App() {
-  // const { currentPath, navigateTo } = useNavigate();
-  const [currentPath, setCurrentPath] = MyReact.useState(window.location.pathname);
-
-  const navigateTo = (path) => {
-    window.history.pushState(null, null, path);
-    setCurrentPath(window.location.pathname);
-  };
+  const { currentPath, navigateTo } = useNavigate();
 
   const routes = [
     {
@@ -28,14 +21,16 @@ export default function App() {
     },
   ];
 
-  return parseHTMLToVDOMTree`
+  const VDOM = parseHTMLToVDOMTree`
     <div class="App">
-    ${MyReact.render(NavBar)}
-    ${MyReact.render(BrowserRouter, {
+    ${render(NavBar)}
+    ${render(BrowserRouter, {
       navigateTo: navigateTo,
       currentPath: currentPath,
       routes: routes,
     })}
     </div>
   `;
+  console.log("app VDOM:", VDOM);
+  return VDOM;
 }

--- a/App.js
+++ b/App.js
@@ -1,13 +1,21 @@
 import Main from "./Main.js";
 import BrowserRouter from "./router.js";
-import { MyReact } from "./MyReact.js";
+// import { render } from "./MyReact.js";
+import MyReact from "./MyReact.js";
 import FetchPage from "./FetchPage.js";
 import { parseHTMLToVDOMTree } from "./utils.js";
 import NavBar from "./NavBar.js";
-import { PathStateContext } from "./PathStateContext.js";
+import useNavigate from "./useNavigate.js";
 
 export default function App() {
+  // const { currentPath, navigateTo } = useNavigate();
   const [currentPath, setCurrentPath] = MyReact.useState(window.location.pathname);
+
+  const navigateTo = (path) => {
+    window.history.pushState(null, null, path);
+    setCurrentPath(window.location.pathname);
+  };
+
   const routes = [
     {
       pathname: "/",
@@ -22,18 +30,11 @@ export default function App() {
 
   return parseHTMLToVDOMTree`
     <div class="App">
-    ${MyReact.render(PathStateContext.Provider, {
-      value: { currentPath: currentPath, setCurrentPath: setCurrentPath },
-      children: [
-        [NavBar, null],
-        [
-          BrowserRouter,
-          {
-            currentPath: currentPath,
-            routes: routes,
-          },
-        ],
-      ],
+    ${MyReact.render(NavBar)}
+    ${MyReact.render(BrowserRouter, {
+      navigateTo: navigateTo,
+      currentPath: currentPath,
+      routes: routes,
     })}
     </div>
   `;

--- a/BreweryItem.js
+++ b/BreweryItem.js
@@ -1,7 +1,7 @@
-import { parseHTMLToRenderTree } from "./utils.js";
+import { parseHTMLToVDOMTree } from "./utils.js";
 
 export default function BreweryItem({ data }) {
-  return parseHTMLToRenderTree`
+  return parseHTMLToVDOMTree`
     <div class="brewery_item">
       Name: ${data?.name}
       Street: ${data?.street}

--- a/Dropdown.js
+++ b/Dropdown.js
@@ -1,0 +1,9 @@
+import { parseHTMLToVDOMTree } from "./utils.js";
+
+export default function Dropdown({ children }) {
+  return parseHTMLToVDOMTree`
+  <div class="dropdown_container">
+    ${children}
+  </div>
+  `;
+}

--- a/FetchPage.js
+++ b/FetchPage.js
@@ -32,7 +32,7 @@ export default function FetchPage({ navigateTo }) {
     <div><button onclick="${() => navigateTo("/")}">go back to main page</button></div>
     <div class="dog_name">name: ${user?.results[0].name.first}</div>
     <img src="${dogImageURL}" alt="" class="dog_photo" /> 
-    <div>${breweries?.map((brewery) => {
+    <div class="brewing_company_list_container">${breweries?.map((brewery) => {
       return MyReact.render(BreweryItem, { data: brewery });
     })}</div>
   </div>

--- a/FetchPage.js
+++ b/FetchPage.js
@@ -1,13 +1,12 @@
 import BreweryItem from "./BreweryItem.js";
 import useCustomHook from "./customHook.js";
-import { MyReact } from "./MyReact.js";
-import useNavigate from "./useNavigate.js";
+// import { render, useState, useEffect } from "./MyReact.js";
+import MyReact from "./MyReact.js";
 import { parseHTMLToVDOMTree } from "./utils.js";
 
-export default function FetchPage() {
+export default function FetchPage({ navigateTo }) {
   const [dogImageURL, setDogImageURL] = MyReact.useState();
   const { user } = useCustomHook();
-  const navigateTo = useNavigate();
   const [breweries, setBreweries] = MyReact.useState();
 
   MyReact.useEffect(() => {

--- a/FetchPage.js
+++ b/FetchPage.js
@@ -1,11 +1,13 @@
 import BreweryItem from "./BreweryItem.js";
 import useCustomHook from "./customHook.js";
 import { MyReact } from "./MyReact.js";
-import { parseHTMLToRenderTree } from "./utils.js";
+import useNavigate from "./useNavigate.js";
+import { parseHTMLToVDOMTree } from "./utils.js";
 
-export default function FetchPage({ navigateTo }) {
+export default function FetchPage() {
   const [dogImageURL, setDogImageURL] = MyReact.useState();
   const { user } = useCustomHook();
+  const navigateTo = useNavigate();
   const [breweries, setBreweries] = MyReact.useState();
 
   MyReact.useEffect(() => {
@@ -26,7 +28,7 @@ export default function FetchPage({ navigateTo }) {
       });
   }, []);
 
-  return parseHTMLToRenderTree`
+  return parseHTMLToVDOMTree`
   <div class="FetchPage">
     <div><button onclick="${() => navigateTo("/")}">go back to main page</button></div>
     <div class="dog_name">name: ${user?.results[0].name.first}</div>

--- a/Main.js
+++ b/Main.js
@@ -5,16 +5,18 @@ import MyReact from "./MyReact.js";
 export default function Main({ navigateTo }) {
   const [counter, setCounter] = MyReact.useState(0);
   const useRefTestRef = MyReact.useRef(0);
-
+  const increaseButtonRef = MyReact.useRef();
+  console.log(setCounter);
   return parseHTMLToVDOMTree`
-  <div class="main">
-    <div class="mainBox" style="width: 10rem; height: 5rem; border: 1px solid black">
+  <main class="MainPage">
+    <div onclick="${() => increaseButtonRef.current.click()}" class="count_box">
       useState counter: ${counter}
       useRef counter: ${useRefTestRef.current}
     </div>
-    <button onclick="${() => setCounter(counter + 1)}">increase useState value</button>
+    <button ref="${increaseButtonRef}" onclick="${() =>
+    setCounter(counter + 1)}">increase useState value</button>
     <button onclick="${() => useRefTestRef.current++}">increase useRef value</button>
     <button onclick="${() => navigateTo("/fetch")}">go to fetch page</button>
-  </div>
+  </main>
   `;
 }

--- a/Main.js
+++ b/Main.js
@@ -1,11 +1,15 @@
 import { MyReact } from "./MyReact.js";
-import { parseHTMLToRenderTree } from "./utils.js";
+import { PathStateContext } from "./PathStateContext.js";
+import useNavigate from "./useNavigate.js";
+import { parseHTMLToVDOMTree } from "./utils.js";
 
-export default function Main({ navigateTo }) {
+export default function Main() {
   const [counter, setCounter] = MyReact.useState(0);
   const useRefTestRef = MyReact.useRef(0);
-
-  return parseHTMLToRenderTree`
+  const navigateTo = useNavigate();
+  const contextValue = MyReact.useContext(PathStateContext);
+  console.log("main component context value:", contextValue);
+  return parseHTMLToVDOMTree`
   <div class="main">
     <div class="mainBox" style="width: 10rem; height: 5rem; border: 1px solid black">
       useState counter: ${counter}

--- a/Main.js
+++ b/Main.js
@@ -1,14 +1,11 @@
-import { MyReact } from "./MyReact.js";
-import { PathStateContext } from "./PathStateContext.js";
-import useNavigate from "./useNavigate.js";
+// import { useState, useRef } from "./MyReact.js";
 import { parseHTMLToVDOMTree } from "./utils.js";
+import MyReact from "./MyReact.js";
 
-export default function Main() {
+export default function Main({ navigateTo }) {
   const [counter, setCounter] = MyReact.useState(0);
   const useRefTestRef = MyReact.useRef(0);
-  const navigateTo = useNavigate();
-  const contextValue = MyReact.useContext(PathStateContext);
-  console.log("main component context value:", contextValue);
+
   return parseHTMLToVDOMTree`
   <div class="main">
     <div class="mainBox" style="width: 10rem; height: 5rem; border: 1px solid black">

--- a/MyReact.js
+++ b/MyReact.js
@@ -1,23 +1,27 @@
 import { RERENDER_EVENT } from "./index.js";
+import { parseHTMLToVDOMTree } from "./utils.js";
 
 export const MyReact = (function () {
-  let hookStates = [];
+  const hookStates = [];
   let currentHookIndex = 0;
-  let effectsToRun = [];
-  let renderedComponentsInSeries = [];
+  const effectsToRun = [];
+  const renderedComponentsInSeries = [];
   let currentComponentIndex = 0;
+  const contexts = [];
 
   return {
     render(Component, props) {
-      if (renderedComponentsInSeries[currentComponentIndex] === undefined) renderedComponentsInSeries.push(Component);
+      if (renderedComponentsInSeries[currentComponentIndex] === undefined)
+        renderedComponentsInSeries.push(Component);
       else if (renderedComponentsInSeries[currentComponentIndex] !== Component) {
         hookStates.splice(currentHookIndex);
         renderedComponentsInSeries[currentComponentIndex] = Component;
       }
       currentComponentIndex++;
 
-      const renderTree = Component(props);
-
+      const VDOMTree = Component(props);
+      console.log("rendered components:", renderedComponentsInSeries);
+      console.log("contexts: ", contexts);
       currentHookIndex = 0;
 
       let runEffectIndex;
@@ -35,8 +39,9 @@ export const MyReact = (function () {
       currentComponentIndex--;
       // console.log("hook states after render: ", JSON.stringify(hookStates));
 
-      return renderTree;
+      return VDOMTree;
     },
+
     useState(initialValue) {
       const thisHookIndex = currentHookIndex;
       if (hookStates[currentHookIndex] === undefined) hookStates.push({ value: initialValue });
@@ -47,20 +52,55 @@ export const MyReact = (function () {
       };
       return [hookStates[currentHookIndex++].value, setState];
     },
+
     useEffect(callback, dependencies) {
       if (hookStates[currentHookIndex] === undefined) {
         hookStates.push({ callback: callback, dependenciesState: dependencies });
         effectsToRun.push({ callback: callback, componentIndex: currentComponentIndex });
-      } else if (!hookStates[currentHookIndex].dependenciesState.every((previousDependencyState, i) => JSON.stringify(previousDependencyState) === JSON.stringify(dependencies[i]))) {
-        effectsToRun.push({ callback: hookStates[currentHookIndex].callback, componentIndex: currentComponentIndex });
+      } else if (
+        !hookStates[currentHookIndex].dependenciesState.every(
+          (previousDependencyState, i) =>
+            JSON.stringify(previousDependencyState) === JSON.stringify(dependencies[i])
+        )
+      ) {
+        effectsToRun.push({
+          callback: hookStates[currentHookIndex].callback,
+          componentIndex: currentComponentIndex,
+        });
       }
       currentHookIndex++;
     },
-    useRef(initialState) {
+
+    useRef(initialValue) {
       if (hookStates[currentHookIndex] === undefined) {
-        hookStates.push({ current: initialState });
+        hookStates.push({ current: initialValue });
       }
       return hookStates[currentHookIndex++];
+    },
+
+    createContext(initialValue) {
+      const context = (() => {
+        let _value = initialValue;
+        return {
+          getValue() {
+            return _value;
+          },
+          Provider({ value, children }) {
+            if (value) _value = value;
+            console.log("_value", _value);
+            return {
+              value: _value,
+              children: children.map((child) => MyReact.render(...child)),
+            };
+          },
+        };
+      })();
+      contexts.push(context);
+      return contexts[contexts.length - 1];
+    },
+
+    useContext(Context) {
+      return Context.getValue();
     },
   };
 })();

--- a/NavBar.js
+++ b/NavBar.js
@@ -1,12 +1,28 @@
+import Dropdown from "./Dropdown.js";
+import { render, useState } from "./MyReact.js";
 import { parseHTMLToVDOMTree } from "./utils.js";
 
 export default function NavBar() {
+  const [isShowingDropdown, setIsShowingDropdown] = useState(false);
+
   return parseHTMLToVDOMTree`
   <div class="NavBar">
     <h1 class="title">MyReactJS</h1>
     <div class="user_info">
-      <div class="avatar">user</div>
+      <div class="avatar" onclick="${() => setIsShowingDropdown(!isShowingDropdown)}">user</div>
     </div>
+    <>${
+      isShowingDropdown
+        ? render(Dropdown, {
+            children: parseHTMLToVDOMTree`
+        <>
+          <div>My Profile</div>
+          <div>Logout </div>
+        </>
+    `,
+          })
+        : ""
+    }</>
   </div>;
   `;
 }

--- a/NavBar.js
+++ b/NavBar.js
@@ -1,0 +1,12 @@
+import { parseHTMLToVDOMTree } from "./utils.js";
+
+export default function NavBar() {
+  return parseHTMLToVDOMTree`
+  <div class="NavBar">
+    <h1 class="title">MyReactJS</h1>
+    <div class="user_info">
+      <div class="avatar">user</div>
+    </div>
+  </div>;
+  `;
+}

--- a/PathStateContext.js
+++ b/PathStateContext.js
@@ -1,3 +1,0 @@
-import { MyReact } from "./MyReact.js";
-
-export const PathStateContext = MyReact.createContext(0);

--- a/PathStateContext.js
+++ b/PathStateContext.js
@@ -1,0 +1,3 @@
+import { MyReact } from "./MyReact.js";
+
+export const PathStateContext = MyReact.createContext(0);

--- a/customHook.js
+++ b/customHook.js
@@ -1,13 +1,13 @@
-import { MyReact } from "./MyReact.js";
-
+// import { useState, useEffect } from "./MyReact.js";
+import MyReact from "./MyReact.js";
 export default function useCustomHook() {
   const [user, setUser] = MyReact.useState();
 
   const getUser = () => {
     fetch("https://randomuser.me/api/")
       .then((res) => res.json())
-      .then((data) => setUser(data))
-      .catch((error) => window.alert("getUser error:", error.message));
+      .then((data) => setUser(data));
+    // .catch((error) => window.alert("getUser error:", error.message));
   };
 
   MyReact.useEffect(() => {

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Document</title>
+    <link rel="stylesheet" href="./style.css" />
   </head>
   <body></body>
   <script src="./index.js" type="module"></script>

--- a/index.js
+++ b/index.js
@@ -4,8 +4,9 @@ import { parseVDOMTreeToDOMTree } from "./utils.js";
 
 export const RENDER_EVENT = "RENDER";
 
-window.addEventListener(RENDER_EVENT, () => {
+window.addEventListener(RENDER_EVENT, (event) => {
   const VDOMTree = MyReact.render(App);
+  console.log("VDOM:", VDOMTree);
   const app = parseVDOMTreeToDOMTree(VDOMTree);
   document.querySelector(".App")?.remove();
   document.querySelector("body").append(app);

--- a/index.js
+++ b/index.js
@@ -1,13 +1,12 @@
 import App from "./App.js";
 import { MyReact } from "./MyReact.js";
-import { parseRenderTreeToDOMTree } from "./utils.js";
+import { parseVDOMTreeToDOMTree } from "./utils.js";
 
 export const RERENDER_EVENT = "RERENDER";
 
 window.addEventListener(RERENDER_EVENT, () => {
-  console.log("render event dispatched");
-  const renderTree = MyReact.render(App);
-  const app = parseRenderTreeToDOMTree(renderTree);
+  const VDOMTree = MyReact.render(App);
+  const app = parseVDOMTreeToDOMTree(VDOMTree);
   document.querySelector(".App")?.remove();
   document.querySelector("body").append(app);
 });

--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 import App from "./App.js";
-import { MyReact } from "./MyReact.js";
+import MyReact from "./MyReact.js";
 import { parseVDOMTreeToDOMTree } from "./utils.js";
 
-export const RERENDER_EVENT = "RERENDER";
+export const RENDER_EVENT = "RENDER";
 
-window.addEventListener(RERENDER_EVENT, () => {
+window.addEventListener(RENDER_EVENT, () => {
   const VDOMTree = MyReact.render(App);
   const app = parseVDOMTreeToDOMTree(VDOMTree);
   document.querySelector(".App")?.remove();
   document.querySelector("body").append(app);
 });
 
-window.dispatchEvent(new CustomEvent(RERENDER_EVENT));
+window.dispatchEvent(new CustomEvent(RENDER_EVENT));

--- a/router.js
+++ b/router.js
@@ -1,12 +1,22 @@
-export default function router(pathname, routes) {
-  const requestedRoute = pathname.match(/\/[a-zA-Z0-9]*/g);
-  return findMatchingPath(requestedRoute, routes);
+import { MyReact } from "./MyReact.js";
+import { parseHTMLToVDOMTree } from "./utils.js";
+
+export default function BrowserRouter({ currentPath, routes }) {
+  console.log("requested route:", currentPath);
+  const requestedRoute = currentPath.match(/\/[a-zA-Z0-9]*/g);
+  const matchingComponent = findMatchingPath(requestedRoute, routes);
+  return parseHTMLToVDOMTree`
+  <>
+    ${MyReact.render(matchingComponent.component)}
+  </>
+  `;
 }
 
 const findMatchingPath = (requestedRoute, routes) => {
   if (requestedRoute === undefined || !routes) return;
   const found = routes.find((e) => e.pathname === requestedRoute[0]);
-  console.log("requestedRoute:", requestedRoute, "found:", found);
-  const foundInChildren = found?.childPaths ? findMatchingPath(requestedRoute.slice(1), found.childPaths) : null;
+  const foundInChildren = found?.childPaths
+    ? findMatchingPath(requestedRoute.slice(1), found.childPaths)
+    : null;
   return foundInChildren ? foundInChildren : found;
 };

--- a/router.js
+++ b/router.js
@@ -1,13 +1,14 @@
-import { MyReact } from "./MyReact.js";
+// import { render } from "./MyReact.js";
+import MyReact from "./MyReact.js";
 import { parseHTMLToVDOMTree } from "./utils.js";
 
-export default function BrowserRouter({ currentPath, routes }) {
+export default function BrowserRouter({ currentPath, routes, navigateTo }) {
   console.log("requested route:", currentPath);
   const requestedRoute = currentPath.match(/\/[a-zA-Z0-9]*/g);
   const matchingComponent = findMatchingPath(requestedRoute, routes);
   return parseHTMLToVDOMTree`
   <>
-    ${MyReact.render(matchingComponent.component)}
+    ${MyReact.render(matchingComponent.component, { navigateTo: navigateTo })}
   </>
   `;
 }

--- a/style.css
+++ b/style.css
@@ -1,0 +1,16 @@
+body {
+  box-sizing: border-box;
+}
+.NavBar {
+  width: 100%;
+  height: 5rem;
+  background-color: rgb(47, 90, 196);
+  color: white;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.NavBar > * {
+  margin: 0 1rem;
+}

--- a/style.css
+++ b/style.css
@@ -1,16 +1,87 @@
+* {
+  font-family: Verdana, Geneva, Tahoma, sans-serif;
+}
 body {
   box-sizing: border-box;
+}
+.App {
+  width: 100%;
+  height: 100%;
+}
+main {
+  margin: 0 auto;
+  width: fit-content;
+}
+main > * {
+  margin: 1rem 0;
+}
+main button {
+  display: block;
 }
 .NavBar {
   width: 100%;
   height: 5rem;
-  background-color: rgb(47, 90, 196);
+  background-color: rgb(87, 69, 185);
   color: white;
   display: flex;
   justify-content: space-between;
   align-items: center;
+  position: relative;
 }
 
 .NavBar > * {
   margin: 0 1rem;
+}
+
+.avatar {
+  border: 2px solid white;
+  border-radius: 50%;
+  width: 3rem;
+  height: 3rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+}
+.dropdown_container {
+  position: absolute;
+  right: 0;
+  margin: 0;
+  top: 100%;
+  background-color: rgb(87, 69, 185);
+  width: 10rem;
+  height: 5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  border: 1px solid white;
+  animation: appear 0.3s linear forwards;
+  z-index: -1;
+}
+
+.dropdown_container > * {
+  border-bottom: 1px solid white;
+  height: 50%;
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+@keyframes appear {
+  0% {
+    top: 0;
+  }
+  100% {
+    top: 100%;
+  }
+}
+
+.count_box {
+  height: 5rem;
+  border: 1px solid black;
+}
+
+.brewing_company_list_container > * {
+  border: 1px solid black;
 }

--- a/useNavigate.js
+++ b/useNavigate.js
@@ -1,14 +1,13 @@
 import { MyReact } from "./MyReact.js";
+import { PathStateContext } from "./PathStateContext.js";
 
 export default function useNavigate() {
-  const [currentPath, setCurrentPath] = MyReact.useState(window.location.pathname);
-
-  console.log("currentPath: ", currentPath);
-
+  console.log("pathStateContext in useContext", PathStateContext.getValue());
+  const { setCurrentPath } = MyReact.useContext(PathStateContext);
   const navigateTo = (path) => {
     setCurrentPath(path);
     window.history.pushState(null, null, path);
   };
 
-  return { currentPath, navigateTo };
+  return navigateTo;
 }

--- a/useNavigate.js
+++ b/useNavigate.js
@@ -1,13 +1,12 @@
-import { MyReact } from "./MyReact.js";
-import { PathStateContext } from "./PathStateContext.js";
-
+// import { useState } from "./MyReact.js";
+import MyReact from "./MyReact.js";
 export default function useNavigate() {
-  console.log("pathStateContext in useContext", PathStateContext.getValue());
-  const { setCurrentPath } = MyReact.useContext(PathStateContext);
+  const [currentPath, setCurrentPath] = MyReact.useState(window.location.pathname);
+  console.log("current path in usenavigate", currentPath);
   const navigateTo = (path) => {
-    setCurrentPath(path);
     window.history.pushState(null, null, path);
+    setCurrentPath(window.location.pathname);
   };
 
-  return navigateTo;
+  return { currentPath, navigateTo };
 }

--- a/utils.js
+++ b/utils.js
@@ -14,21 +14,21 @@ Number.prototype.isEndIndexOf = function (data) {
   return this === data.length - 1;
 };
 
-const isInnerText = (index, brokenHTML) => {
-  const closestUpcomingIndexOf = (char, startingArrayIndex, array) => {
-    let piece = array[startingArrayIndex];
-    let offset = Math.max(piece.indexOf(char), 0);
-    while (piece.indexOf(char) < 0) {
-      offset += piece.length;
-      piece = brokenHTML[startingArrayIndex++];
-    }
-    return offset + piece.indexOf(char);
-  };
+// const isInnerText = (index, brokenHTML) => {
+//   const closestUpcomingIndexOf = (char, startingArrayIndex, array) => {
+//     let piece = array[startingArrayIndex];
+//     let offset = Math.max(piece.indexOf(char), 0);
+//     while (piece.indexOf(char) < 0) {
+//       offset += piece.length;
+//       piece = brokenHTML[startingArrayIndex++];
+//     }
+//     return offset + piece.indexOf(char);
+//   };
 
-  return (
-    closestUpcomingIndexOf("<", index, brokenHTML) < closestUpcomingIndexOf(">", index, brokenHTML)
-  );
-};
+//   return (
+//     closestUpcomingIndexOf("<", index, brokenHTML) < closestUpcomingIndexOf(">", index, brokenHTML)
+//   );
+// };
 
 export function parseHTMLToVDOMTree(brokenHTML, ...variables) {
   const regexForTagAndTextSelection = /<[\s\S]*?(?=<\/?)/g;

--- a/utils.js
+++ b/utils.js
@@ -25,24 +25,46 @@ const isInnerText = (index, brokenHTML) => {
     return offset + piece.indexOf(char);
   };
 
-  return closestUpcomingIndexOf("<", index, brokenHTML) < closestUpcomingIndexOf(">", index, brokenHTML);
+  return (
+    closestUpcomingIndexOf("<", index, brokenHTML) < closestUpcomingIndexOf(">", index, brokenHTML)
+  );
 };
 
-export function parseHTMLToRenderTree(brokenHTML, ...variables) {
+export function parseHTMLToVDOMTree(brokenHTML, ...variables) {
   const regexForTagAndTextSelection = /<[\s\S]*?(?=<\/?)/g;
   const regexForAttributes = /[a-z]+="[0-9a-zA-Z=_\-:;/.\[\]\s]+"/g;
-  const singletonTags = ["area", "base", "br", "col", "command", "embed", "hr", "img", "input", "keygen", "link", "meta", "source", "track", "wbr"];
+  const singletonTags = [
+    "area",
+    "base",
+    "br",
+    "col",
+    "command",
+    "embed",
+    "hr",
+    "img",
+    "input",
+    "keygen",
+    "link",
+    "meta",
+    "source",
+    "track",
+    "wbr",
+  ];
   let joinedHTML;
-  console.log(brokenHTML, variables);
+
   //write variables indexes into html for future parsing
   if (variables) {
     let varIndex = 0;
-    joinedHTML = brokenHTML.map((HTMLPiece, pieceIndex) => HTMLPiece + (pieceIndex.isEndIndexOf(brokenHTML) ? "" : `[${varIndex++}]`)).join("");
+    joinedHTML = brokenHTML
+      .map(
+        (HTMLPiece, pieceIndex) =>
+          HTMLPiece + (pieceIndex.isEndIndexOf(brokenHTML) ? "" : `[${varIndex++}]`)
+      )
+      .join("");
   } else joinedHTML = brokenHTML[0];
 
   //splits html into opening tag + inner text / closing tag
   const htmlArr = joinedHTML.match(regexForTagAndTextSelection);
-  console.log("htmlarr:", htmlArr);
 
   function recursivelyParseHTML(htmlArr) {
     if (htmlArr.length < 1) return;
@@ -64,7 +86,6 @@ export function parseHTMLToRenderTree(brokenHTML, ...variables) {
         indexes = matchingVariables.map((e) => e.replace("[", "").replace("]", ""));
         indexes.forEach((index) => {
           if (variables[index] instanceof Object) {
-            console.log("variable: ", variables[index], variables[index] instanceof Array);
             if (variables[index] instanceof Array) children.push(...variables[index]);
             else children.push(variables[index]);
             innerText = innerText.replace(`[${index}]`, "");
@@ -72,27 +93,33 @@ export function parseHTMLToRenderTree(brokenHTML, ...variables) {
         });
       }
     }
-    console.log("children", children);
+
     //remove white spaces between tags
     if (!innerText.replaceAll(" ", "").replaceAll("\n", "")) innerText = null;
     else if (innerText.startsWith("\n")) innerText = innerText.replace("\n", "");
 
     //get tag name
-    const tagName = openingTag.match(/[a-z0-9]+/)[0];
-
+    let tagName = openingTag?.match(/[a-z0-9]+/);
+    if (tagName) tagName = tagName[0];
     //get attributes
-    const attributesArr = openingTag.match(regexForAttributes);
-    const attributesObj =
-      attributesArr?.reduce((prev, curr) => {
-        if (curr.match(/=/)) {
-          let [attribute, value] = curr.split("=");
-          attribute = attribute.replaceAll(/\s/g, "").replace("class", "className");
-          if (value.match(/\[[0-9]+\]/)) value = variables[parseInt(value.match(/[0-9]+/)[0])];
-          return { ...prev, [attribute]: typeof value === "string" ? value.replaceAll('"', "") : value };
-        } else {
-          return { ...prev, [curr]: true };
-        }
-      }, {}) || [];
+    let attributesArr, attributesObj;
+    if (tagName) {
+      attributesArr = openingTag.match(regexForAttributes);
+      attributesObj =
+        attributesArr?.reduce((prev, curr) => {
+          if (curr.match(/=/)) {
+            let [attribute, value] = curr.split("=");
+            attribute = attribute.replaceAll(/\s/g, "").replace("class", "className");
+            if (value.match(/\[[0-9]+\]/)) value = variables[parseInt(value.match(/[0-9]+/)[0])];
+            return {
+              ...prev,
+              [attribute]: typeof value === "string" ? value.replaceAll('"', "") : value,
+            };
+          } else {
+            return { ...prev, [curr]: true };
+          }
+        }, {}) || [];
+    }
 
     let childElements;
 
@@ -104,17 +131,28 @@ export function parseHTMLToRenderTree(brokenHTML, ...variables) {
         if (childElements) children.push(childElements);
       } while (childElements);
 
-    return { tagName: tagName, ...attributesObj, text: innerText, children: children.length > 0 ? children : null };
+    return tagName
+      ? {
+          tagName: tagName,
+          ...attributesObj,
+          text: innerText,
+          children: children.length > 0 ? children : null,
+        }
+      : { children: children.length > 0 ? children : null };
   }
 
   return recursivelyParseHTML(htmlArr);
 }
 
-export function parseRenderTreeToDOMTree(renderTree) {
-  if (!renderTree) return;
-  const { tagName, className, text, children, ...attributes } = renderTree;
-  const element = createElement(tagName, className, attributes, text);
-  const childrenElements = renderTree.children?.map((child) => parseRenderTreeToDOMTree(child));
-  if (childrenElements) element.append(...childrenElements);
-  return element;
+export function parseVDOMTreeToDOMTree(VDOMTree) {
+  if (!VDOMTree) return;
+  const { tagName, className, text, children, ...attributes } = VDOMTree;
+  let childElements = VDOMTree.children?.map((child) => parseVDOMTreeToDOMTree(child));
+  if (childElements) childElements = childElements.flat();
+  if (tagName) {
+    const element = createElement(tagName, className, attributes, text);
+    if (Object.keys(attributes).includes("ref")) attributes.ref.current = element;
+    if (childElements) element.append(...childElements);
+    return element;
+  } else return childElements;
 }


### PR DESCRIPTION
MyReact state handling mechanism has been changed to organizing states by its belonging component. Now the hook index only applies for inside of each component. 

Also, each component state object keeps status of whether mounted, so that the state object can be removed after unmount. 

This fixed previous issues of serialized states when dealing with path change with different components mounting/unmounting & having divergent tree of component inheritance. 